### PR TITLE
Fix CRAN check errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: EpiForsk
 Title: Code Sharing at the Department of Epidemiology Research at Statens Serum Institut 
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: 
     c(person("Anders", "Husby", , "andh@ssi.dk", role = c("aut"),
              comment = c(ORCID = "0000-0002-7634-8455")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: EpiForsk
 Title: Code Sharing at the Department of Epidemiology Research at Statens Serum Institut 
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     c(person("Anders", "Husby", , "andh@ssi.dk", role = c("aut"),
              comment = c(ORCID = "0000-0002-7634-8455")),

--- a/R/adls_flatten_dates_dt.R
+++ b/R/adls_flatten_dates_dt.R
@@ -102,6 +102,9 @@ FlattenDatesDT <- function(
     overlap_handling = c("none", "first", "most_recent"),
     lag = 0
 ) {
+  # Avoid NSE notes in R CMD check
+  merge_id <- NULL
+
   # Input checks
   overlap_handling <- match.arg(overlap_handling)
 
@@ -130,14 +133,14 @@ FlattenDatesDT <- function(
   # Mark merge groups by cumsum of gaps > lag
   data[
     ,
-    merge_id := cumsum(c(FALSE, head(get(out_date), -1) + lag < tail(get(in_date), -1))),
+    merge_id := cumsum(c(FALSE, utils::head(get(out_date), -1) + lag < utils::tail(get(in_date), -1))),
     by = grp_key
   ]
 
   # Collapse each merge_id to [min(start), max(end)]
   result <- data[
     ,
-    .(
+    list(
       tmp_start = min(get(in_date)),
       tmp_end = max(get(out_date))
     ),

--- a/R/kija_fct_confint.R
+++ b/R/kija_fct_confint.R
@@ -1003,6 +1003,9 @@ ci_fct <- function(i,
                    level,
                    n_grid,
                    k) {
+  # Disable problematic solvers
+  CVXR::exclude_solvers("MOSEK")
+  on.exit(CVXR::include_solvers("MOSEK"))
   # find ci_lower
   beta <- CVXR::Variable(dim(xtx_red)[1])
   objective <- CVXR::Minimize(f(beta)[i])


### PR DESCRIPTION
- Define variables used inside data.table globally to avoid NSE notes in R CMD check
- Temporarily disable MOSEK solver in CVXR when using the convex solver to avoid a CRAN check error
- Bump package version to 0.2.2